### PR TITLE
Add error handling for command line app

### DIFF
--- a/bin/generate-flame-graph
+++ b/bin/generate-flame-graph
@@ -15,11 +15,19 @@ if (functionNames) functionNames = functionNames.split(/\s+/).map(name => name.t
 
 async function main () {
   if (command) {
-    console.log(await generateFlameGraphForCommand(command, {functionNames, fullPage: true}))
+    try {
+      console.log(await generateFlameGraphForCommand(command, {functionNames, fullPage: true}))
+    } catch (e) {
+      console.error(`Failed to generate flame graph for "${command}":\n\n${e.message}`);
+    }
   } else if (pid) {
     const {html, stop} = generateFlameGraphForProcess(pid, {functionNames, fullPage: true})
     process.on('SIGINT', () => stop())
-    console.log(await html)
+    try {
+      console.log(await html)
+    } catch (e) {
+      console.error(`Failed to generate flame graph for PID ${pid}:\n\n${e.message}`);
+    }
     process.exit(0)
   } else {
     console.log(


### PR DESCRIPTION
For example, prior to this change, if sudo failed for dtrace, you'd get an error similar to the following:

```
(node:30600) UnhandledPromiseRejectionWarning: Error: Dtrace processes failed. Code: 1, Stderr: Sorry, try again.
Sorry, try again.
sudo: 3 incorrect password attempts

    at ChildProcess.dtraceProcess.on.code (/Users/josh/src/node-flame-graph/src/generate-flame-graph.js:78:25)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:915:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
(node:30600) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:30600) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

After this change:

```
Failed to generate flame graph for "/usr/local/bin/my-node-app":

Dtrace processes failed. Code: 1, Stderr: Sorry, try again.
Sorry, try again.
sudo: 3 incorrect password attempts
```